### PR TITLE
Set landscape layout for calendar PDF

### DIFF
--- a/src/pdf_renderer.py
+++ b/src/pdf_renderer.py
@@ -1,4 +1,4 @@
-from reportlab.lib.pagesizes import letter
+from reportlab.lib.pagesizes import letter, landscape
 from reportlab.pdfgen import canvas
 from reportlab.lib import colors
 from calendar import monthrange, day_name
@@ -11,7 +11,7 @@ def build_calendar_pdf(notes, zip_code, month, year, filename=None):
     """
     if filename is None:
         filename = f"calendar_{zip_code}_{year}_{month:02d}.pdf"
-    c = canvas.Canvas(filename, pagesize=letter)
+    c = canvas.Canvas(filename, pagesize=landscape(letter))
     width, height = letter
     margin = 40
     grid_top = height - margin - 40


### PR DESCRIPTION
## Summary
- configure `build_calendar_pdf` to create PDFs in landscape orientation

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68643bfa183883258ecdbd4e0b0d781e