### PR TITLE
Add configurable layout for PDF rendering

### DIFF
--- a/src/pdf_renderer.py
+++ b/src/pdf_renderer.py
@@ -2,6 +2,16 @@ from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas
 from reportlab.lib import colors
 from calendar import monthrange, day_name
+import json
+from pathlib import Path
+
+# Load layout configuration
+CONFIG_PATH = Path(__file__).resolve().parents[1] / "templates" / "layout_config.json"
+try:
+    with open(CONFIG_PATH) as f:
+        LAYOUT_CONFIG = json.load(f)
+except FileNotFoundError:
+    LAYOUT_CONFIG = {}
 
 
 def build_calendar_pdf(notes, zip_code, month, year, filename=None):
@@ -13,46 +23,63 @@ def build_calendar_pdf(notes, zip_code, month, year, filename=None):
         filename = f"calendar_{zip_code}_{year}_{month:02d}.pdf"
     c = canvas.Canvas(filename, pagesize=letter)
     width, height = letter
-    margin = 40
-    grid_top = height - margin - 40
+
+    cfg = LAYOUT_CONFIG
+    margin = cfg.get("page_margin", 40)
+    header_height = cfg.get("header_height", 40)
+    rows = cfg.get("rows", 5)
+    cols = cfg.get("cols", 7)
+
+    fonts_cfg = cfg.get("fonts", {})
+    day_font = fonts_cfg.get("day_name", {"name": "Helvetica-Bold", "size": 12})
+    date_font = fonts_cfg.get("date", {"name": "Helvetica-Bold", "size": 14})
+    note_font = fonts_cfg.get("note", {"name": "Helvetica", "size": 10})
+    icon_font = fonts_cfg.get("icon", {"name": "Helvetica-Oblique", "size": 8})
+
+    grid_top = height - margin - header_height
     grid_left = margin
     grid_width = width - 2 * margin
-    grid_height = height - 2 * margin - 40
-    cell_width = grid_width / 7
-    cell_height = grid_height / 5
+    grid_height = height - 2 * margin - header_height
+
+    cell_cfg = cfg.get("cell_size", {})
+    cell_width = cell_cfg.get("width", grid_width / cols)
+    cell_height = cell_cfg.get("height", grid_height / rows)
+    if "width" in cell_cfg:
+        grid_width = cell_width * cols
+    if "height" in cell_cfg:
+        grid_height = cell_height * rows
 
     # Draw day names
     for i, day in enumerate(["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]):
-        c.setFont("Helvetica-Bold", 12)
+        c.setFont(day_font["name"], day_font["size"])
         c.drawCentredString(grid_left + cell_width * (i + 0.5), grid_top + 20, day)
 
     # Get first weekday and number of days
     first_weekday, num_days = monthrange(year, month)
     day_counter = 1
-    for row in range(5):
-        for col in range(7):
+    for row in range(rows):
+        for col in range(cols):
             x = grid_left + col * cell_width
             y = grid_top - row * cell_height
             c.setStrokeColor(colors.black)
             c.rect(x, y - cell_height, cell_width, cell_height, stroke=1, fill=0)
             # Only fill in valid days
-            cell_num = row * 7 + col
             if (row == 0 and col < first_weekday) or day_counter > num_days:
                 continue
             # Date string
             date_str = f"{year:04d}-{month:02d}-{day_counter:02d}"
             note = notes.get(date_str, {})
             # Bold date in top-left
-            c.setFont("Helvetica-Bold", 14)
+            c.setFont(date_font["name"], date_font["size"])
             c.drawString(x + 5, y - 18, str(day_counter))
             # Notes below date
-            c.setFont("Helvetica", 10)
+            c.setFont(note_font["name"], note_font["size"])
             if note.get("Line_1"):
                 c.drawString(x + 5, y - 32, note["Line_1"])
             if note.get("Line_2"):
                 c.drawString(x + 5, y - 44, note["Line_2"])
             # Reserve bottom right for icons (placeholder)
-            c.setFont("Helvetica-Oblique", 8)
+            c.setFont(icon_font["name"], icon_font["size"])
             c.setFillColor(colors.grey)
             c.drawRightString(x + cell_width - 5, y - cell_height + 14, "[icon]")
             c.setFillColor(colors.black)

--- a/templates/layout_config.json
+++ b/templates/layout_config.json
@@ -1,0 +1,16 @@
+{
+  "page_margin": 40,
+  "header_height": 40,
+  "rows": 5,
+  "cols": 7,
+  "cell_size": {
+    "width": 76,
+    "height": 134
+  },
+  "fonts": {
+    "day_name": {"name": "Helvetica-Bold", "size": 12},
+    "date": {"name": "Helvetica-Bold", "size": 14},
+    "note": {"name": "Helvetica", "size": 10},
+    "icon": {"name": "Helvetica-Oblique", "size": 8}
+  }
+}


### PR DESCRIPTION
## Summary
- establish `templates/layout_config.json` with margins, fonts and cell sizes
- load config in `pdf_renderer.py` and apply values when drawing calendar

## Testing
- `python calendar_runner.py -z 12345 -m 7 -y 2025`

------
https://chatgpt.com/codex/tasks/task_e_68643f6d88f883258bda259ae4ab0323