### PR TITLE
Fix flake8 warnings and clean imports

### DIFF
--- a/calendar_runner.py
+++ b/calendar_runner.py
@@ -3,13 +3,35 @@ from src.generator import generate_calendar
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Generate a ZIP-specific nature calendar.")
-    parser.add_argument("-z", "--zip", type=str, default="63901", help="5-digit ZIP code (default: 63901)")
-    parser.add_argument("-m", "--month", type=int, help="Month as number (1–12)")
-    parser.add_argument("-y", "--year", type=int, help="Year as 4-digit number (e.g. 2025)")
+    parser = argparse.ArgumentParser(
+        description="Generate a ZIP-specific nature calendar."
+    )
+    parser.add_argument(
+        "-z",
+        "--zip",
+        type=str,
+        default="63901",
+        help="5-digit ZIP code (default: 63901)",
+    )
+    parser.add_argument(
+        "-m",
+        "--month",
+        type=int,
+        help="Month as number (1–12)",
+    )
+    parser.add_argument(
+        "-y",
+        "--year",
+        type=int,
+        help="Year as 4-digit number (e.g. 2025)",
+    )
     args = parser.parse_args()
 
-    generate_calendar(zip_code=args.zip, month=args.month, year=args.year)
+    generate_calendar(
+        zip_code=args.zip,
+        month=args.month,
+        year=args.year,
+    )
     print("✅ Calendar generation complete.")
 
 

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -1,5 +1,4 @@
 import json
-import os
 from pathlib import Path
 from calendar import monthrange
 from typing import Dict
@@ -9,8 +8,14 @@ import requests
 # Example static data for demonstration
 STATIC_NOTES = {
     "12345": {
-        "2025-07-01": {"Line_1": "Bird migration peak", "Line_2": "Fishing: Trout season"},
-        "2025-07-02": {"Line_1": "Wildflowers bloom", "Line_2": "Hunting: Deer archery"},
+        "2025-07-01": {
+            "Line_1": "Bird migration peak",
+            "Line_2": "Fishing: Trout season",
+        },
+        "2025-07-02": {
+            "Line_1": "Wildflowers bloom",
+            "Line_2": "Hunting: Deer archery",
+        },
         # ... more days ...
     },
     # ... more zip codes ...
@@ -52,7 +57,11 @@ def _load_external_notes(source: str) -> Dict[str, Dict[str, str]]:
     return {}
 
 
-def get_notes_for_zip(zip_code: str, month: int, year: int) -> Dict[str, Dict[str, str]]:
+def get_notes_for_zip(
+    zip_code: str,
+    month: int,
+    year: int,
+) -> Dict[str, Dict[str, str]]:
     """Returns a dict mapping YYYY-MM-DD to notes for each day."""
 
     notes: Dict[str, Dict[str, str]] = {}
@@ -73,9 +82,15 @@ def get_notes_for_zip(zip_code: str, month: int, year: int) -> Dict[str, Dict[st
         # Pin hunting/fishing to Line_2 if present
         line_1 = day_note.get("Line_1", "")
         line_2 = day_note.get("Line_2", "")
-        if ("hunting" in line_1.lower() or "fishing" in line_1.lower()) and not line_2:
+        if (
+            "hunting" in line_1.lower()
+            or "fishing" in line_1.lower()
+        ) and not line_2:
             line_2, line_1 = line_1, ""
-        elif ("hunting" in line_2.lower() or "fishing" in line_2.lower()) and line_1:
+        elif (
+            "hunting" in line_2.lower()
+            or "fishing" in line_2.lower()
+        ) and line_1:
             pass  # already in Line_2
         notes[date_str] = {"Line_1": line_1, "Line_2": line_2}
     return notes

--- a/src/generator.py
+++ b/src/generator.py
@@ -2,6 +2,7 @@ from datetime import date
 from src.data_loader import get_notes_for_zip
 from src.pdf_renderer import build_calendar_pdf
 
+
 def generate_calendar(zip_code, month=None, year=None):
     today = date.today()
     month = month or today.month

--- a/src/pdf_renderer.py
+++ b/src/pdf_renderer.py
@@ -1,12 +1,14 @@
 from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas
 from reportlab.lib import colors
-from calendar import monthrange, day_name
+from calendar import monthrange
 import json
 from pathlib import Path
 
 # Load layout configuration
-CONFIG_PATH = Path(__file__).resolve().parents[1] / "templates" / "layout_config.json"
+CONFIG_PATH = (
+    Path(__file__).resolve().parents[1] / "templates" / "layout_config.json"
+)
 try:
     with open(CONFIG_PATH) as f:
         LAYOUT_CONFIG = json.load(f)
@@ -31,10 +33,16 @@ def build_calendar_pdf(notes, zip_code, month, year, filename=None):
     cols = cfg.get("cols", 7)
 
     fonts_cfg = cfg.get("fonts", {})
-    day_font = fonts_cfg.get("day_name", {"name": "Helvetica-Bold", "size": 12})
+    day_font = fonts_cfg.get(
+        "day_name",
+        {"name": "Helvetica-Bold", "size": 12},
+    )
     date_font = fonts_cfg.get("date", {"name": "Helvetica-Bold", "size": 14})
     note_font = fonts_cfg.get("note", {"name": "Helvetica", "size": 10})
-    icon_font = fonts_cfg.get("icon", {"name": "Helvetica-Oblique", "size": 8})
+    icon_font = fonts_cfg.get(
+        "icon",
+        {"name": "Helvetica-Oblique", "size": 8},
+    )
 
     grid_top = height - margin - header_height
     grid_left = margin
@@ -52,7 +60,11 @@ def build_calendar_pdf(notes, zip_code, month, year, filename=None):
     # Draw day names
     for i, day in enumerate(["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]):
         c.setFont(day_font["name"], day_font["size"])
-        c.drawCentredString(grid_left + cell_width * (i + 0.5), grid_top + 20, day)
+        c.drawCentredString(
+            grid_left + cell_width * (i + 0.5),
+            grid_top + 20,
+            day,
+        )
 
     # Get first weekday and number of days
     first_weekday, num_days = monthrange(year, month)
@@ -62,7 +74,14 @@ def build_calendar_pdf(notes, zip_code, month, year, filename=None):
             x = grid_left + col * cell_width
             y = grid_top - row * cell_height
             c.setStrokeColor(colors.black)
-            c.rect(x, y - cell_height, cell_width, cell_height, stroke=1, fill=0)
+            c.rect(
+                x,
+                y - cell_height,
+                cell_width,
+                cell_height,
+                stroke=1,
+                fill=0,
+            )
             # Only fill in valid days
             if (row == 0 and col < first_weekday) or day_counter > num_days:
                 continue
@@ -81,7 +100,11 @@ def build_calendar_pdf(notes, zip_code, month, year, filename=None):
             # Reserve bottom right for icons (placeholder)
             c.setFont(icon_font["name"], icon_font["size"])
             c.setFillColor(colors.grey)
-            c.drawRightString(x + cell_width - 5, y - cell_height + 14, "[icon]")
+            c.drawRightString(
+                x + cell_width - 5,
+                y - cell_height + 14,
+                "[icon]",
+            )
             c.setFillColor(colors.black)
             day_counter += 1
     c.save()


### PR DESCRIPTION
## Summary
- remove unused imports
- wrap long lines in `pdf_renderer.py`, `data_loader.py`, and `calendar_runner.py`
- add blank line in generator module
- confirm flake8 passes

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_68672ec09070832587f8f9c418e30df1