### PR TITLE
Add unit tests for data loader and PDF renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,12 @@ python calendar_runner.py --zip 12345 --month 7 --year 2025
 ```
 
 This will read notes for ZIP code `12345` from the configured source and output a PDF calendar.
+
+## Running tests
+
+Install dependencies and run the unit tests with `pytest`:
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,0 +1,51 @@
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src import data_loader
+
+
+def test_load_external_notes_local(tmp_path):
+    data = {"day": {"Line_1": "note"}}
+    file = tmp_path / "notes.json"
+    file.write_text(json.dumps(data))
+    result = data_loader._load_external_notes(str(file))
+    assert result == data
+
+
+def test_load_external_notes_remote(monkeypatch):
+    returned = {"x": {"Line_2": "remote"}}
+
+    class DummyResp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return returned
+
+    def mock_get(url, timeout=10):
+        assert url == "http://example.com/data.json"
+        return DummyResp()
+
+    monkeypatch.setattr(data_loader.requests, "get", mock_get)
+    result = data_loader._load_external_notes("http://example.com/data.json")
+    assert result == returned
+
+
+def test_get_notes_for_zip_swaps_lines(monkeypatch):
+    sample = {"2025-07-01": {"Line_1": "Fishing event"}}
+
+    monkeypatch.setattr(data_loader, "_load_zip_sources", lambda: {"11111": "foo"})
+    monkeypatch.setattr(data_loader, "_load_external_notes", lambda source: sample)
+
+    notes = data_loader.get_notes_for_zip("11111", 7, 2025)
+    swapped = notes["2025-07-01"]
+    assert swapped["Line_1"] == ""
+    assert swapped["Line_2"] == "Fishing event"
+    assert len(notes) == 31

--- a/tests/test_pdf_renderer.py
+++ b/tests/test_pdf_renderer.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src import pdf_renderer
+
+
+def test_build_calendar_pdf_creates_file(tmp_path):
+    notes = {
+        "2025-07-01": {"Line_1": "A", "Line_2": "B"},
+        "2025-07-02": {"Line_1": "", "Line_2": ""},
+    }
+    outfile = tmp_path / "calendar.pdf"
+    pdf_renderer.build_calendar_pdf(notes, "12345", 7, 2025, filename=str(outfile))
+    assert outfile.exists()
+    assert outfile.stat().st_size > 0


### PR DESCRIPTION
## Summary
- add `tests/` directory with unit tests covering `data_loader.py` and `pdf_renderer.py`
- make `src` a package to allow imports in tests
- document running the tests in `README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866def69f84832598fba5e425da9355