### PR TITLE
Fix Sunday-first layout in PDF calendar

### DIFF
--- a/src/pdf_renderer.py
+++ b/src/pdf_renderer.py
@@ -56,6 +56,7 @@ def build_calendar_pdf(notes, zip_code, month, year, filename=None):
 
     # Get first weekday and number of days
     first_weekday, num_days = monthrange(year, month)
+    first_weekday = (first_weekday + 1) % 7  # convert Monday=0 to Sunday=0
     day_counter = 1
     for row in range(rows):
         for col in range(cols):


### PR DESCRIPTION
## Summary
- adjust `first_weekday` so that calendars start on Sunday
- verify PDF generation works

## Testing
- `pip install -r requirements.txt`
- `python calendar_runner.py --zip 12345 --month 7 --year 2025`

------
https://chatgpt.com/codex/tasks/task_e_6866df0bc6ec8325877e24177f5caa4a