### PR TITLE
Handle dynamic calendar rows

### DIFF
--- a/templates/layout_config.json
+++ b/templates/layout_config.json
@@ -2,6 +2,7 @@
   "page_margin": 40,
   "header_height": 40,
   "rows": 5,
+  "dynamic_rows": true,
   "cols": 7,
   "cell_size": {
     "width": 76,


### PR DESCRIPTION
## Summary
- allow `pdf_renderer.build_calendar_pdf` to determine required rows
- shrink cell height if more rows are needed
- allow row expansion in `layout_config.json`

## Testing
- `pip install -r requirements.txt`
- `python calendar_runner.py --zip 63901 --month 1 --year 2025`

------
https://chatgpt.com/codex/tasks/task_e_6866df0d03ec8325b3f9401ca5979a7f